### PR TITLE
Refactor ParserBuilder cloning and fix reference counting of log messages

### DIFF
--- a/syslog-ng-common/Cargo.toml
+++ b/syslog-ng-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syslog-ng-common"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Tibor Benke <ihrwein@gmail.com>"]
 homepage = "https://github.com/ihrwein/syslog-ng-rs"
 repository = "https://github.com/ihrwein/syslog-ng-rs"

--- a/syslog-ng-common/Cargo.toml
+++ b/syslog-ng-common/Cargo.toml
@@ -10,4 +10,4 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 log = "0.3"
-syslog-ng-sys = "^0.2.1"
+syslog-ng-sys = "^0.2.2"

--- a/syslog-ng-common/src/logmsg/mod.rs
+++ b/syslog-ng-common/src/logmsg/mod.rs
@@ -37,7 +37,8 @@ impl LogMessage {
     }
 
     pub fn wrap_raw(raw: *mut ::sys::LogMessage) -> LogMessage {
-        LogMessage(raw)
+        let referenced = unsafe {logmsg::log_msg_ref(raw)};
+        LogMessage(referenced)
     }
 
     unsafe fn c_char_to_str<'a>(value: *const c_char, len: ssize_t) -> &'a str {

--- a/syslog-ng-common/src/proxies/parser/mod.rs
+++ b/syslog-ng-common/src/proxies/parser/mod.rs
@@ -15,7 +15,7 @@ mod proxy;
 pub use self::option_error::OptionError;
 pub use self::proxy::ParserProxy;
 
-pub trait ParserBuilder: Clone {
+pub trait ParserBuilder {
     type Parser: Parser;
     fn new() -> Self;
     fn option(&mut self, name: String, value: String);

--- a/syslog-ng-common/src/proxies/parser/proxy.rs
+++ b/syslog-ng-common/src/proxies/parser/proxy.rs
@@ -12,7 +12,6 @@ use LogParser;
 pub use proxies::parser::{OptionError, Parser, ParserBuilder};
 
 #[repr(C)]
-#[derive(Clone)]
 pub struct ParserProxy<B>
     where B: ParserBuilder
 {
@@ -64,5 +63,12 @@ impl<B> ParserProxy<B> where B: ParserBuilder
                           .as_mut()
                           .expect("Failed to get a builder on a new parser proxy instance");
         builder.parent(parent);
+    }
+}
+
+impl<B> Clone for ParserProxy<B> where B: ParserBuilder {
+    fn clone(&self) -> ParserProxy<B> {
+        // it makes no sense to clone() the builder
+        ParserProxy {parser: self.parser.clone(), builder: None}
     }
 }

--- a/syslog-ng-sys/Cargo.toml
+++ b/syslog-ng-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syslog-ng-sys"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Tibor Benke <ihrwein@gmail.com>"]
 build = "build.rs"
 links = "syslog-ng"

--- a/syslog-ng-sys/src/logmsg.rs
+++ b/syslog-ng-sys/src/logmsg.rs
@@ -28,6 +28,7 @@ pub type LogMessageTagsForeachFunc = extern "C" fn(// msg:
 #[link(name = "syslog-ng")]
 extern "C" {
     pub fn log_msg_unref(m: *mut LogMessage) -> ();
+    pub fn log_msg_ref(m: *mut LogMessage) -> *mut LogMessage;
     pub fn log_msg_get_value_handle(value_name: *const c_char) -> NVHandle;
     pub fn __log_msg_get_value(m: *const LogMessage,
                                handle: NVHandle,


### PR DESCRIPTION
- `ParserBuilder` doesn't have to implement `Clone`
- fix reference counting bug in log messages
